### PR TITLE
Grammar: “it’s” → “its” (determiner, not contraction)

### DIFF
--- a/data/org.gnome.parlatype.appdata.xml.in
+++ b/data/org.gnome.parlatype.appdata.xml.in
@@ -8,7 +8,7 @@
 	<_summary>Media player for manual speech transcription</_summary>
 
 	<description>
-		<_p>Parlatype is an easy to use media player. It's main purpose is to help
+		<_p>Parlatype is an easy to use media player. Its main purpose is to help
       you transcribing speech.</_p>
 	</description>
 

--- a/docs/parlatype.1
+++ b/docs/parlatype.1
@@ -26,7 +26,7 @@ parlatype \- minimal audio player for manual speech transcription
 .SH DESCRIPTION
 .B parlatype
 is an audio player for the GNOME desktop environment.
-It's main purpose is the manual transcription of spoken audio files.
+Its main purpose is the manual transcription of spoken audio files.
 .SH OPTIONS
 .B parlatype
 follows the usual GNU command line syntax, with long

--- a/help/C/index.page
+++ b/help/C/index.page
@@ -11,7 +11,7 @@
   <email>gabor.karsay@gmx.at</email>
 </credit>
 <include href="legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
-<desc><app>Parlatype</app> is an easy to use media player. It's main purpose is to help you transcribing speech.</desc>
+<desc><app>Parlatype</app> is an easy to use media player. Its main purpose is to help you transcribing speech.</desc>
 
 </info>
 
@@ -20,7 +20,7 @@
   Parlatype
 </title>
 
-<p><app>Parlatype</app> is an easy to use media player. It's main purpose is to help you transcribing speech.</p>
+<p><app>Parlatype</app> is an easy to use media player. Its main purpose is to help you transcribing speech.</p>
 <p>For a quick overview have a look at <link xref="first-steps" />. Other topics are covered below.</p>
 
 <section id="topics" style="2column">

--- a/help/de/de.po
+++ b/help/de/de.po
@@ -46,7 +46,7 @@ msgstr "Gabor Karsay"
 #. (itstool) path: page/p
 #: C/index.page:14 C/index.page:23
 msgid ""
-"<app>Parlatype</app> is an easy to use media player. It's main purpose is to "
+"<app>Parlatype</app> is an easy to use media player. Its main purpose is to "
 "help you transcribing speech."
 msgstr ""
 "<app>Parlatype</app> ist ein einfach zu bedienender Medienspieler. Er dient "

--- a/help/en_GB/en_GB.po
+++ b/help/en_GB/en_GB.po
@@ -49,7 +49,7 @@ msgstr "Gabor Karsay"
 #. (itstool) path: page/p
 #: C/index.page:14 C/index.page:23
 msgid ""
-"<app>Parlatype</app> is an easy to use media player. It's main purpose is to "
+"<app>Parlatype</app> is an easy to use media player. Its main purpose is to "
 "help you transcribing speech."
 msgstr ""
 "<app>Parlatype</app> is an easy to use media player. Its main purpose is to "

--- a/help/he/he.po
+++ b/help/he/he.po
@@ -39,7 +39,7 @@ msgstr ""
 #. (itstool) path: page/p
 #: C/index.page:14 C/index.page:23
 msgid ""
-"<app>Parlatype</app> is an easy to use media player. It's main purpose is to "
+"<app>Parlatype</app> is an easy to use media player. Its main purpose is to "
 "help you transcribing speech."
 msgstr ""
 

--- a/help/id/id.po
+++ b/help/id/id.po
@@ -54,7 +54,7 @@ msgstr "Gabor Karsay"
 #: C/index.page:14
 #: C/index.page:23
 msgid ""
-"<app>Parlatype</app> is an easy to use media player. It's main purpose is to "
+"<app>Parlatype</app> is an easy to use media player. Its main purpose is to "
 "help you transcribing speech."
 msgstr ""
 "<app>Parlatype</app> adalah pemutar media yang mudah digunakan. Tujuan "

--- a/help/it/it.po
+++ b/help/it/it.po
@@ -49,7 +49,7 @@ msgstr "Gabor Karsay"
 #. (itstool) path: page/p
 #: C/index.page:14 C/index.page:23
 msgid ""
-"<app>Parlatype</app> is an easy to use media player. It's main purpose is to "
+"<app>Parlatype</app> is an easy to use media player. Its main purpose is to "
 "help you transcribing speech."
 msgstr ""
 "<app>Parlatype</app> è un lettore multimediale facile da usare. Il suo scopo "

--- a/help/ku/ku.po
+++ b/help/ku/ku.po
@@ -54,7 +54,7 @@ msgstr "Gabor Karsay"
 #: C/index.page:14
 #: C/index.page:23
 msgid ""
-"<app>Parlatype</app> is an easy to use media player. It's main purpose is to "
+"<app>Parlatype</app> is an easy to use media player. Its main purpose is to "
 "help you transcribing speech."
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -31,7 +31,7 @@ msgstr "Reproductor de mitjans per a la transcripció manual de veu"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 "Parlatype és un reproductor de mitjans fàcil d'usar. El seu principal "

--- a/po/de.po
+++ b/po/de.po
@@ -31,7 +31,7 @@ msgstr "Medienwiedergabe für manuelle Sprachtranskription"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 "Parlatype ist ein einfach zu bedienender Medienspieler. Er dient "

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -31,7 +31,7 @@ msgstr "Media player for manual speech transcription"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 "Parlatype is an easy to use media player. Its main purpose is to help you "

--- a/po/es.po
+++ b/po/es.po
@@ -31,7 +31,7 @@ msgstr "Reproductor de medios para la transcripción de voz manual"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 "Parlatype es un reproductor de medios fácil de usar. Su principal propósito "

--- a/po/fr.po
+++ b/po/fr.po
@@ -31,7 +31,7 @@ msgstr "Lecteur média pour la transcription manuelle de discours"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 "Parlatype est un lecteur média simple d'utilisation. Il est conçu pour "

--- a/po/he.po
+++ b/po/he.po
@@ -31,7 +31,7 @@ msgstr ""
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -31,7 +31,7 @@ msgstr "Pemutar media untuk transkrip pembicaraan manual"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 "Parlatype adalah pemutar media yang mudah digunakan. Tujuan utamanya adalah "

--- a/po/it.po
+++ b/po/it.po
@@ -31,7 +31,7 @@ msgstr "Lettore multimediale per la trascrizione vocale manuale"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 "Parlatype è un lettore multimediale facile da usare. Il suo scopo principale "

--- a/po/kab.po
+++ b/po/kab.po
@@ -31,7 +31,7 @@ msgstr ""
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 

--- a/po/ku.po
+++ b/po/ku.po
@@ -31,7 +31,7 @@ msgstr ""
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 

--- a/po/ms.po
+++ b/po/ms.po
@@ -31,7 +31,7 @@ msgstr "Pemain media untuk transripsi pertuturan manual"
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -31,7 +31,7 @@ msgstr ""
 
 #: ../data/org.gnome.parlatype.appdata.xml.in.h:3
 msgid ""
-"Parlatype is an easy to use media player. It's main purpose is to help you "
+"Parlatype is an easy to use media player. Its main purpose is to help you "
 "transcribing speech."
 msgstr ""
 


### PR DESCRIPTION
This trivial patch is the result of running `git grep -l "It's main purpose" | xargs sed -i "s/It's main purpose/Its main purpose/g"`. Detected the typo as I started working on a translation for the help files.