### PR TITLE
[Packaging] Add experimental Flatpak support

### DIFF
--- a/com.github.gkarsay.parlatype.json
+++ b/com.github.gkarsay.parlatype.json
@@ -1,0 +1,75 @@
+{
+    "app-id": "com.github.gkarsay.parlatype",
+    "branch": "stable",
+    
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.24",
+    "sdk": "org.gnome.Sdk",
+    
+    "command": "parlatype",
+    
+    "rename-icon": "parlatype",
+    
+    "tags": [],
+    
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        
+        "--filesystem=host",
+        
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--talk-name=org.freedesktop.secrets",
+        
+        "--own-name=com.github.gkarsay.parlatype"
+    ],
+    "build-options" : {
+        "cflags" : "-O2 -g"
+    },
+    "cleanup": [
+        "*.la",
+        "*.a",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/bash-completion",
+        "/share/gtk-doc",
+        "/share/man"
+    ],
+    "modules": [
+        {
+            "name" : "gst-libav",
+            "config-opts" : [
+            
+             ],
+            "cleanup" : [
+                "*.la"
+            ],
+            "sources" : [
+                {
+                    "type"   : "git",
+                    "url"    : "git://anongit.freedesktop.org/gstreamer/gst-libav",
+                    "branch" : "1.8"
+                }
+            ]
+        },
+        {
+            "name": "parlatype",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/gkarsay/parlatype.git",
+                    "branch": "v1.5.1"
+                }
+            ]
+        }
+    ]
+}
+

--- a/com.github.gkarsay.parlatype.json
+++ b/com.github.gkarsay.parlatype.json
@@ -45,22 +45,6 @@
     ],
     "modules": [
         {
-            "name" : "gst-libav",
-            "config-opts" : [
-            
-             ],
-            "cleanup" : [
-                "*.la"
-            ],
-            "sources" : [
-                {
-                    "type"   : "git",
-                    "url"    : "git://anongit.freedesktop.org/gstreamer/gst-libav",
-                    "branch" : "1.8"
-                }
-            ]
-        },
-        {
             "name": "parlatype",
             "sources": [
                 {


### PR DESCRIPTION
This pull request adds experimental Flatpak support suggested in issue #9. It was tested against release version 1.5.1. I don't know how familiar you are with Flatpak so I tried to go into detail.

## Prepare system
Install basic GNOME SDK & Platform for version 3.24
```
flatpak remote-add --if-not-exists gnome https://sdk.gnome.org/gnome.flatpakrepo
flatpak install gnome org.gnome.Sdk//3.24
flatpak install gnome org.gnome.Platform//3.24
```

## Building
Download the `com.github.gkarsay.parlatype.json` somewhere you want to build your project, ex `~/Projects/parlatype-flatpak/com.github.gkarsay.parlatype.json`.

Next run `flatpak-builder` to build the flatpak locally in the `repo` repo.
```
flatpak-builder --force-clean --repo=repo parlatype com.github.gkarsay.parlatype.json
```

Now install the local repo to act as a real repo, that repo will be called `parlatype`. This would be the same as if you installed packages from `gnome`, `flathub`, etc.. So it's not really important since it's local.
```
flatpak --user remote-add --no-gpg-verify --if-not-exists parlatype repo
```

Next install `parlatype`. I'm passing the `--user` command so it's not global (you need to pass this if you wish to remove it later.
```
flatpak --user install parlatype com.github.gkarsay.parlatype
```

Now run:
```
flatpak run com.github.gkarsay.parlatype
```

Now you can run the first `flatpak-builder` command to rebuild the package if you update it. Users can then update their flatpak from the `parlatype` repo which is pulling from the local repo named `repo` with:
```
flatpak --user update com.github.gkarsay.parlatype
```

To remove the app & repo:
```
flatpak --user uninstall com.github.gkarsay.parlatype
flatpak --user remote-delete parlatype
```

## Notes
### Accessibility
If you see the following message in the terminal at start:

```
** (parlatype:2): WARNING **: Couldn't connect to accessibility bus: Failed to connect to socket /tmp/dbus-DxXTqmk8qO: Connection refuse
```
this is because accessibility bus is not implemented, see [flatpak/issues/79](https://github.com/flatpak/flatpak/issues/79).

I'm not sure if this can be suppressed or maybe build parlatype without it?

### App ID
Because Parlatype declares the DBus name `com.github.gkarsay.parlatype` the flatpak-builder json manifest file and the app-id must also be `com.github.gkarsay.parlatype`. This includes capitalization, so `com.github.gkarsay.Parlatype` would be different. That got me the first time.

### App Icon
Flatpak wants the application icon installed in the default `share/icons` folder to follow the same pattern as the application id, because of this the Flatpak contains the `"rename-icon": "parlatype",` line in the manifest. This renames the `parlatype.(png|svg)` files to `com.github.gkarsay.parlatype.(png|svg)`. This breaks the icons in the About/Info window.

Maybe consider standardizing the icon names with the application name? Most GNOME apps do this already.

### Libreoffice
Since this is a sandboxed app I'm not sure how this would work? If at all.

### Feature checking
I don't use Parlatype a lot if at all, so this pull request is "experimental" simply because I don't know if something is missing. I tried most of the features in the UI and played with the settings. Everything seems to work from what I can tell.

### Flathub
If you feel this flatpak is or will eventully be in a good position then I recommend submitting it to Flathub. Flathub makes it easier for users to find, install and use Flatpak apps (like Parlatype).

More info: https://github.com/flathub/flathub
Review Process: https://github.com/flathub/flathub/wiki/Review-Guidelines