### PR TITLE
README: update GStreamer MP3 support req's

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Required runtime dependencies:
 * GStreamer
 * GStreamer "Good" Plugins
 
-Optional runtime dependencies, to support MP3 files:
-* GStreamer "Ugly" Plugins
+If using GStreamer 1.14+, MP3 support is included in the "Good" Plugins, so nothing else is needed.
+Otherwise, optional runtime dependencies to support MP3 files:
+* GStreamer "Ugly" Plugins (only with GStreamer <= 1.12)
 
 Optional runtime dependencies, if you want to use LibreOffice macros:
 * LibreOffice (>= 4)


### PR DESCRIPTION
As of GStreamer 1.14, MP3 support has been moved to the "Good" plugins (see the "Plugin and library moves" section of [the GStreamer 1.14 release notes](https://gstreamer.freedesktop.org/releases/1.14/)), so the GStreamer "Bad" Plugins dependency is no longer present past GStreamer 1.12.