### PR TITLE
Add --disable-rpath to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,9 +47,10 @@ AC_SUBST([WARNINGCFLAGS])
 # Check if rpath is disabled
 AC_MSG_CHECKING(whether to use rpath)
 AC_ARG_ENABLE(rpath,
-	[AC_HELP_STRING([--disable-rpath],
-			[Patches libtool to not use rpath in the libraries produced.])],
-	[parlatype_use_rpath="$enable_rpath"], [parlatype_use_rpath="yes"])
+	[AS_HELP_STRING([--enable-rpath],
+			[Whether to set rpath in the libraries produced [default=yes]])],
+	[parlatype_use_rpath=$enableval],
+	[parlatype_use_rpath=yes])
 AC_MSG_RESULT($parlatype_use_rpath)
 
 # Patch libtool to not use rpath if requested.

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,25 @@ PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= $GTK_MIN_VERSION, gmodule-2.0])
 WARNINGCFLAGS="-Wall"
 AC_SUBST([WARNINGCFLAGS])
 
+# Check if rpath is disabled
+AC_MSG_CHECKING(whether to use rpath)
+AC_ARG_ENABLE(rpath,
+	[AC_HELP_STRING([--disable-rpath],
+			[Patches libtool to not use rpath in the libraries produced.])],
+	[parlatype_use_rpath="$enable_rpath"], [parlatype_use_rpath="yes"])
+AC_MSG_RESULT($parlatype_use_rpath)
+
+# Patch libtool to not use rpath if requested.
+#
+AC_CONFIG_COMMANDS([libtool-rpath-patch],
+[if test "$libtool_patch_use_rpath" = "no"; then
+   echo config.status: patching libtool to not use rpath
+   sed < libtool > libtool-2 's/^hardcode_libdir_flag_spec.*$'/'hardcode_libdir_flag_spec=" -D__LIBTOOL_NO_RPATH__ "/'
+   mv libtool-2 libtool
+   chmod 755 libtool
+fi],
+[libtool_patch_use_rpath=$parlatype_use_rpath])
+
 AC_ARG_WITH([libreoffice],
             [AS_HELP_STRING([--without-libreoffice],
               [don't install LibreOffice macros])],

--- a/libparlatype/configure.ac
+++ b/libparlatype/configure.ac
@@ -84,6 +84,24 @@ AC_ARG_ENABLE([tests],
 
 AM_CONDITIONAL(WITH_TESTS, [test "$tests" = "yes"])
 
+# Check if rpath is disabled
+AC_MSG_CHECKING(whether to use rpath)
+AC_ARG_ENABLE(rpath,
+	[AC_HELP_STRING([--disable-rpath],
+			[Patches libtool to not use rpath in the libraries produced.])],
+	[libparlatype_use_rpath="$enable_rpath"], [libparlatype_use_rpath="yes"])
+AC_MSG_RESULT($libparlatype_use_rpath)
+
+# Patch libtool to not use rpath if requested.
+#
+AC_CONFIG_COMMANDS([libtool-rpath-patch],
+[if test "$libtool_patch_use_rpath" = "no"; then
+   echo config.status: patching libtool to not use rpath
+   sed < libtool > libtool-2 's/^hardcode_libdir_flag_spec.*$'/'hardcode_libdir_flag_spec=" -D__LIBTOOL_NO_RPATH__ "/'
+   mv libtool-2 libtool
+   chmod 755 libtool
+fi],
+[libtool_patch_use_rpath=$libparlatype_use_rpath])
 
 GLIB_TESTS
 AX_VALGRIND_DFLT([memcheck], [on])

--- a/libparlatype/configure.ac
+++ b/libparlatype/configure.ac
@@ -87,9 +87,10 @@ AM_CONDITIONAL(WITH_TESTS, [test "$tests" = "yes"])
 # Check if rpath is disabled
 AC_MSG_CHECKING(whether to use rpath)
 AC_ARG_ENABLE(rpath,
-	[AC_HELP_STRING([--disable-rpath],
-			[Patches libtool to not use rpath in the libraries produced.])],
-	[libparlatype_use_rpath="$enable_rpath"], [libparlatype_use_rpath="yes"])
+	[AS_HELP_STRING([--enable-rpath],
+			[Whether to set rpath in the libraries produced [default=yes]])],
+	[libparlatype_use_rpath=$enableval],
+	[libparlatype_use_rpath=yes])
 AC_MSG_RESULT($libparlatype_use_rpath)
 
 # Patch libtool to not use rpath if requested.


### PR DESCRIPTION
This adds a `--disable-rpath` option to the configure script for both the root directory and libparlatype, which (when explicitly requested) will patch the generated libtool so that it will not set RPATH in the resulting binaries.

This is necessary for packaging on some Linux distributions (e.g. Fedora) which prohibit the use of RPATH in packaged binaries/libraries.